### PR TITLE
2022.4.0.0 Version Update

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+  1 channels:
+  2     psteyer-tests: test1

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-  1 channels:
-  2     psteyer-tests: test1
+channels:
+    psteyer: stubs

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-    psteyer: stubs
+    psteyer-tests: stubs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
   host:
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,8 @@ about:
   summary: Typing stubs for pytz
   license: Apache-2.0 AND MIT
   license_file: LICENSE
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://typing.readthedocs.io/en/latest/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,18 +9,18 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-pytz-{{ version }}.tar.gz
   sha256: 47cfb19c52b9f75896440541db392fd312a35b279c6307a531db71152ea63e2b
+  skip: True # [py<36]
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
   run:
-    - python >=3.6
+    - python
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
-  skip: True # [py<36]
+  skip: True # [py<37]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,11 +9,11 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-pytz-{{ version }}.tar.gz
   sha256: 17d66e4b16e80ceae0787726f3a22288df7d3f9fdebeb091dc64b92c0e4ea09d
-  skip: True # [py<36]
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
+  skip: True # [py<36]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "types-pytz" %}
-{% set version = "2022.2.1.0" %}
+{% set version = "2022.4.0.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-pytz-{{ version }}.tar.gz
-  sha256: 47cfb19c52b9f75896440541db392fd312a35b279c6307a531db71152ea63e2b
+  sha256: 17d66e4b16e80ceae0787726f3a22288df7d3f9fdebeb091dc64b92c0e4ea09d
   skip: True # [py<36]
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,8 @@ requirements:
 
 test:
   commands:
-    - test -f $SP_DIR/pytz-stubs/__init__.pyi
+    - test -f $SP_DIR/pytz-stubs/__init__.pyi # [not win]
+    - if not exist %SP_DIR%\pytz-stubs\__init__.pyi exit 1 # [win]
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,10 @@ requirements:
     - python
 
 test:
+  requires:
+    - pip
   commands:
+    - pip check
     - test -f $SP_DIR/pytz-stubs/__init__.pyi # [not win]
     - if not exist %SP_DIR%\pytz-stubs\__init__.pyi exit 1 # [win]
 


### PR DESCRIPTION
Updating from `2022.2.1.0`-> `2022.4.0.0`

Dependency update for `pandas-stubs`

Related to older PR for older build: https://github.com/AnacondaRecipes/types-pytz-feedstock/pull/2